### PR TITLE
chore: rename "Examples" to "Examples To do"

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Examples
+          Examples To do
         </a>
         <a
           href="https://turborepo.com?utm_source=create-turbo"


### PR DESCRIPTION
Changed the text of the Examples link to "Examples To do" on the docs app homepage.